### PR TITLE
added cstdlib to includes

### DIFF
--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -37,6 +37,7 @@
 #include <iostream>
 #include <vector>
 #include <errno.h>
+#include <cstdlib>
 
 #undef min
 #undef max


### PR DESCRIPTION
The build failed because exit was not declared in this scope.
Exit is defined in cstdlib, so i added it to the includes.
