### PR TITLE
Fixed one memory leak

### DIFF
--- a/src/plugins/playerbot/ChatFilter.h
+++ b/src/plugins/playerbot/ChatFilter.h
@@ -9,6 +9,7 @@ namespace ai
     public:
         ChatFilter(PlayerbotAI* ai) : PlayerbotAIAware(ai) {}
         virtual string Filter(string message);
+        virtual ~ChatFilter() {}
     };
 
     class CompositeChatFilter : public ChatFilter


### PR DESCRIPTION
Destructors of classes inheriting from ChatFilter did not get called.

For example:
RtiChatFilter has a member `list<std::string> rtis;` which was never destroyed.